### PR TITLE
スキル変動が4つ以上あった場合のスキル読み取り判定の修正

### DIFF
--- a/app/lib/crafting_result/crafting_result.py
+++ b/app/lib/crafting_result/crafting_result.py
@@ -197,6 +197,10 @@ def get_skills(screenshot_path, index, is_offset):
 
             skills.append((name_text, value))
 
+    # 4スキル以上出た場合、災禍転福が-1されているとして処理する
+    if is_offset:
+        skills.append("Coalescence", -1)
+
     return skills
 
 


### PR DESCRIPTION
- スキル変動が4つ以上あった場合、災禍転福が-1されていると判定する処理を追加